### PR TITLE
Stdlib dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,4 +8,4 @@ description 'This module provides two resource types for managing configuration 
 project_page 'https://github.com/ryanycoleman/rcoleman-mac_profiles_handler'
 
 ## Add dependencies, if any:
-# dependency 'username/name', '>= 1.2.0'
+dependency 'puppetlabs/stdlib', '>= 2.3.1'

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ mac_profiles_handler::manage { 'com.puppetlabs.myprofile':
 
 You must pass the profilers identifier as your namevar, ensure accepts present or absent and file_source behaves the same way source behaves for file.
 
+## Dependencies
+
+* [puppetlabs/stdlib >= 2.3.1](https://forge.puppetlabs.com/puppetlabs/stdlib)
+
 ## To-Do
 Improve provider parsing.  
 Handle more types of configuration profiles.  


### PR DESCRIPTION
This module needs stdlib for `$::puppet_vardir`. This should be documented.
