### PR TITLE
Force the install date to be a string

### DIFF
--- a/lib/facter/profiles.rb
+++ b/lib/facter/profiles.rb
@@ -17,7 +17,7 @@ Facter.add(:profiles) do
           'verification_state' => item['spconfigprofile_verification_state'],
           'uuid' => item['spconfigprofile_profile_uuid'],
           'organization' => item['spconfigprofile_organization'],
-          'install_date' => DateTime.parse(item['spconfigprofile_install_date'].scan(/\(([^\)]+)\)/).last.first),
+          'install_date' => DateTime.parse(item['spconfigprofile_install_date'].scan(/\(([^\)]+)\)/).last.first).to_s,
           'payload' => []
         }
 


### PR DESCRIPTION
The installed date was returning nil - which made me sad. This forces it to be a string - the worst case scenario is we get an empty string. I guess Facter can't display date things. Silly Facter.
